### PR TITLE
Fix game over button bug that caused lives to decrease continuously

### DIFF
--- a/script.js
+++ b/script.js
@@ -782,12 +782,16 @@ document.addEventListener('keydown', (e) => {
     keys[e.code] = true;
     if (e.code === 'Space') {
         e.preventDefault();
-        
+
         if (gameState === 'stageClear') {
             nextStage();
+        } else if (gameState === 'gameOver' || gameState === 'gameWin') {
+            // ゲームオーバーまたはゲームクリア時はスペースキーを押しても何もしない
+            // 再開ボタンを使用する必要がある
+            return;
         } else {
             gameRunning = !gameRunning;
-            if (gameRunning && (gameState === 'ready' || gameState === 'gameOver' || gameState === 'gameWin')) {
+            if (gameRunning && gameState === 'ready') {
                 gameState = 'playing';
             }
         }
@@ -813,9 +817,13 @@ canvas.addEventListener('mousemove', (e) => {
 canvas.addEventListener('click', (e) => {
     if (gameState === 'stageClear') {
         nextStage();
+    } else if (gameState === 'gameOver' || gameState === 'gameWin') {
+        // ゲームオーバーまたはゲームクリア時はクリックしても何もしない
+        // 再開ボタンを使用する必要がある
+        return;
     } else {
         gameRunning = !gameRunning;
-        if (gameRunning && (gameState === 'ready' || gameState === 'gameOver' || gameState === 'gameWin')) {
+        if (gameRunning && gameState === 'ready') {
             gameState = 'playing';
         }
     }


### PR DESCRIPTION
Previously, clicking or pressing space during game over would toggle gameRunning and set gameState to 'playing', but the ball remained in the fallen state (y > canvas.height). This caused updateBall() to continuously decrement lives every frame.

Fixed by preventing any game state changes when gameState is 'gameOver' or 'gameWin'. Users must now use the restart button to begin a new game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)